### PR TITLE
Initial prototype of Alohacam installer script.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/lanikai.env

--- a/install.sh
+++ b/install.sh
@@ -55,7 +55,7 @@ fi
 if [ ! -e $CERTFILE ]; then
     if [ -z "$TOKEN" ]; then
         echo "Visit the Alohacam dashboard to obtain an activation token for this device:"
-        echo "    $DASHBOARD_URL/devices/activate"
+        echo "    $DASHBOARD_URL/devices/"
         while [ -z "$TOKEN" ]; do
             read -r -p "Enter activation token: "
             TOKEN=$(echo "$REPLY" | tr -cd '0-9A-Za-z')

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash -e
+
+# Check for dependencies.
+hash curl openssl
+
+DASHBOARD_URL=https://alohacam.lanikailabs.com
+API_URL=https://api.alohacam.lanikailabs.com
+DOWNLOAD_URL=https://download.alohacam.lanikailabs.com
+VERSION=latest
+KEYFILE=key.pem
+CERTFILE=cert.pem
+CSRFILE=req.pem
+
+[ -e lanikai.env ] && source lanikai.env
+
+
+# Identify platform and architecture.
+if [ -z "$PLAT" ]; then
+    case "$OSTYPE" in
+        linux*)
+            PLAT=linux ;;
+        *)
+            echo "Unsupported platform: $OSTYPE"
+            exit 1 ;;
+    esac
+fi
+if [ -z "$ARCH" ]; then
+    case "$(uname -m)" in
+        armv6*)
+            ARCH=armv6 ;;
+        armv7*)
+            ARCH=armv7 ;;
+        *)
+            echo "Unsupported architecture: $(uname -m)"
+            exit 1 ;;
+    esac
+fi
+
+# Download latest alohacam binary.
+if [ -z "$SKIP_DOWNLOAD" ]; then
+    curl -o alohacam $DOWNLOAD_URL/release/$VERSION/alohacam-$PLAT-$ARCH
+    chmod a+x alohacam
+fi
+
+# Generate a private key, if we don't already have one.
+if [ ! -e $KEYFILE ]; then
+    echo "Generating private key"
+    openssl ecparam -name prime256v1 -genkey -out $KEYFILE
+
+    rm -f $CERTFILE
+fi
+
+# Request a certificate, if we don't already have one.
+if [ ! -e $CERTFILE ]; then
+    if [ -z "$TOKEN" ]; then
+        echo "Visit the Alohacam dashboard to obtain an activation token for this device:"
+        echo "    $DASHBOARD_URL/devices/activate"
+        while [ -z "$TOKEN" ]; do
+            read -r -p "Enter activation token: "
+            TOKEN=$(echo "$REPLY" | tr -cd '0-9A-Za-z')
+        done
+    fi
+
+    # Generate a certificate signing request. The activation token is included as
+    # the Subject Common Name.
+    openssl req -new -key $KEYFILE -subj "/CN=Activation:$TOKEN" -out $CSRFILE
+
+    # Submit CSR with activation request. If successful, we'll receive a PEM-encoded
+    # certificate in response.
+    if curl -fsSL -F "csr=<$CSRFILE" -o $CERTFILE "$API_URL/activate-device/$TOKEN"; then
+        echo "Success. You may now run Alohacam."
+        rm -f $CSRFILE
+    else
+        echo "Unable to activate your device."
+        echo "Try requesting a new activation code."
+    fi
+fi
+
+
+# TODO: Identify camera type, load kernel modules, install systemd service.


### PR DESCRIPTION
Currently it only does two things:
 1. Downloads the appropriate `alohacam` binary.
 2. Requests a certificate from Oahu, using the device activation flow.

Ideally we would also like it to check the hardware and install
appropriate kernel modules, and possibly install a service to launch
`alohacam` on boot. Those features can be added later.

The script requires URLs for the dashboard, API server, and download
server. For now these are hard-coded to non-existent locations (based at
`alohacam.lanikailabs.com`, which will presumably be our production
deployment). But they can be overridden with an environment file for
development/testing, e.g. my local `lanikai.env` file currently
contains:
```
PLAT=linux
ARCH=armv6
API_URL=api.localhost:8080
DOWNLOAD_URL=localhost:8086
VERSION=dev
```